### PR TITLE
fix: use full paths for Go tools in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ test:
 
 # Run linter
 lint:
-	golangci-lint run
+	$(shell go env GOPATH)/bin/golangci-lint run
 
 # Format code
 fmt:
 	gofmt -w .
-	goimports -w .
+	$(shell go env GOPATH)/bin/goimports -w .
 
 # Clean build artifacts
 clean:


### PR DESCRIPTION
- Fix goimports and golangci-lint commands to use GOPATH/bin paths
- Ensures make targets work regardless of PATH configuration
- All make targets now function correctly