### PR TITLE
feat: implement global cache system with comprehensive unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AI Rules Manager (ARM)
+![arm-header](./assets/arm-header.png)
 
 A package manager for AI coding assistant rulesets. Install, update, and manage coding rules across different AI tools like Cursor and Amazon Q Developer.
 
@@ -107,13 +107,7 @@ authToken = $COMPANY_REGISTRY_TOKEN
 After installation, your project will look like:
 
 ```
-.arm/
-  cache/
-    company/
-      typescript-rules/
-        1.0.1/
-          rule-1.md
-          rule-2.md
+# Project files
 .cursorrules/
   arm/
     company/
@@ -132,6 +126,19 @@ After installation, your project will look like:
 rules.json
 rules.lock
 .armrc
+
+# Global cache (shared across projects)
+~/.arm/
+  cache/
+    packages/
+      registry.armjs.org/
+        typescript-rules/
+          1.0.1/
+            package.tar.gz
+    registry/
+      registry.armjs.org/
+        metadata.json
+        versions.json
 ```
 
 ## Development Status

--- a/docs/project/tasks/p4-1-cache-system.md
+++ b/docs/project/tasks/p4-1-cache-system.md
@@ -10,21 +10,18 @@ Implement comprehensive caching system for downloaded rulesets, registry metadat
 - Implement cache expiration policies
 
 ## Tasks
-- [ ] **Cache storage structure**:
+- [x] **Cache storage structure**:
   ```
-  .mpm/cache/
+  ~/.arm/cache/
     packages/
-      <source>/
+      <registry-host>/
         <ruleset>/
           <version>/
             package.tar.gz
-            metadata.json
     registry/
-      <source>/
+      <registry-host>/
         metadata.json
         versions.json
-    temp/
-      downloads/
   ```
 - [ ] **Package caching**:
   - Store downloaded .tar.gz files

--- a/internal/cache/manager.go
+++ b/internal/cache/manager.go
@@ -1,0 +1,76 @@
+package cache
+
+import (
+	"fmt"
+	"io"
+	"log"
+)
+
+type Manager struct {
+	storage  *Storage
+	packages *PackageCache
+	metadata *MetadataCache
+	config   CacheConfig
+}
+
+func NewManager(config ...CacheConfig) (*Manager, error) {
+	cfg := DefaultConfig
+	if len(config) > 0 {
+		cfg = config[0]
+	}
+
+	storage, err := New()
+	if err != nil {
+		log.Printf("Cache initialization failed, falling back to no-cache mode: %v", err)
+		return &Manager{config: cfg}, nil // Return manager without storage for fallback
+	}
+
+	return &Manager{
+		storage:  storage,
+		packages: NewPackageCache(storage, cfg),
+		metadata: NewMetadataCache(storage, cfg),
+		config:   cfg,
+	}, nil
+}
+
+func (m *Manager) GetPackage(registryURL, ruleset, version string) (string, bool) {
+	if m.packages == nil {
+		return "", false
+	}
+	return m.packages.Get(registryURL, ruleset, version)
+}
+
+func (m *Manager) StorePackage(registryURL, ruleset, version string, data io.Reader) (string, error) {
+	if m.packages == nil {
+		return "", fmt.Errorf("cache not available")
+	}
+	return m.packages.Store(registryURL, ruleset, version, data)
+}
+
+func (m *Manager) GetVersions(registryURL string) ([]string, bool) {
+	if m.metadata == nil {
+		return nil, false
+	}
+	return m.metadata.GetVersions(registryURL)
+}
+
+func (m *Manager) StoreVersions(registryURL string, versions []string) error {
+	if m.metadata == nil {
+		return nil // Silently ignore if cache not available
+	}
+	return m.metadata.StoreVersions(registryURL, versions)
+}
+
+func (m *Manager) GetMetadata(registryURL string) (map[string]interface{}, bool) {
+	if m.metadata == nil {
+		return nil, false
+	}
+	return m.metadata.GetMetadata(registryURL)
+}
+
+func (m *Manager) StoreMetadata(registryURL string, metadata map[string]interface{}) error {
+	if m.metadata == nil {
+		return nil // Silently ignore if cache not available
+	}
+	return m.metadata.StoreMetadata(registryURL, metadata)
+}

--- a/internal/cache/manager_test.go
+++ b/internal/cache/manager_test.go
@@ -1,0 +1,97 @@
+package cache
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestManagerFallback(t *testing.T) {
+	// Test manager creation when home directory is not accessible
+	originalHome := os.Getenv("HOME")
+	_ = os.Setenv("HOME", "/nonexistent")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+
+	manager, err := NewManager()
+	if err != nil {
+		t.Fatalf("Manager creation should not fail: %v", err)
+	}
+
+	// Manager should work in fallback mode
+	if manager.storage != nil {
+		t.Error("Expected nil storage in fallback mode")
+	}
+
+	// Operations should gracefully handle missing cache
+	if _, found := manager.GetPackage("test", "test", "1.0.0"); found {
+		t.Error("Expected cache miss in fallback mode")
+	}
+
+	if versions, found := manager.GetVersions("test"); found || versions != nil {
+		t.Error("Expected no versions in fallback mode")
+	}
+
+	// Store operations should not error
+	if err := manager.StoreVersions("test", []string{"1.0.0"}); err != nil {
+		t.Errorf("StoreVersions should not error in fallback mode: %v", err)
+	}
+}
+
+func TestManagerIntegration(t *testing.T) {
+	// Set up temporary home directory
+	tmpHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	_ = os.Setenv("HOME", tmpHome)
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+
+	manager, err := NewManager()
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	registryURL := "https://registry.armjs.org/"
+	ruleset := "typescript-rules"
+	version := "1.0.0"
+
+	// Test package operations
+	testData := strings.NewReader("test package data")
+	path, err := manager.StorePackage(registryURL, ruleset, version, testData)
+	if err != nil {
+		t.Fatalf("Failed to store package: %v", err)
+	}
+
+	cachedPath, found := manager.GetPackage(registryURL, ruleset, version)
+	if !found {
+		t.Error("Expected to find cached package")
+	}
+	if cachedPath != path {
+		t.Errorf("Cached path %q != stored path %q", cachedPath, path)
+	}
+
+	// Test metadata operations
+	versions := []string{"1.0.0", "1.1.0"}
+	if err := manager.StoreVersions(registryURL, versions); err != nil {
+		t.Fatalf("Failed to store versions: %v", err)
+	}
+
+	cachedVersions, found := manager.GetVersions(registryURL)
+	if !found {
+		t.Error("Expected to find cached versions")
+	}
+	if len(cachedVersions) != len(versions) {
+		t.Errorf("Cached versions length %d != stored length %d", len(cachedVersions), len(versions))
+	}
+
+	metadata := map[string]interface{}{"test": "data"}
+	if err := manager.StoreMetadata(registryURL, metadata); err != nil {
+		t.Fatalf("Failed to store metadata: %v", err)
+	}
+
+	cachedMetadata, found := manager.GetMetadata(registryURL)
+	if !found {
+		t.Error("Expected to find cached metadata")
+	}
+	if cachedMetadata["test"] != metadata["test"] {
+		t.Errorf("Cached metadata %v != stored %v", cachedMetadata, metadata)
+	}
+}

--- a/internal/cache/metadata.go
+++ b/internal/cache/metadata.go
@@ -1,0 +1,84 @@
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type MetadataCache struct {
+	storage *Storage
+	config  CacheConfig
+}
+
+func NewMetadataCache(storage *Storage, config CacheConfig) *MetadataCache {
+	return &MetadataCache{
+		storage: storage,
+		config:  config,
+	}
+}
+
+func (mc *MetadataCache) GetVersions(registryURL string) ([]string, bool) {
+	var versions []string
+	if mc.get(registryURL, "versions.json", mc.config.VersionTTL, &versions) {
+		return versions, true
+	}
+	return nil, false
+}
+
+func (mc *MetadataCache) StoreVersions(registryURL string, versions []string) error {
+	return mc.store(registryURL, "versions.json", versions)
+}
+
+func (mc *MetadataCache) GetMetadata(registryURL string) (map[string]interface{}, bool) {
+	var metadata map[string]interface{}
+	if mc.get(registryURL, "metadata.json", mc.config.MetadataTTL, &metadata) {
+		return metadata, true
+	}
+	return nil, false
+}
+
+func (mc *MetadataCache) StoreMetadata(registryURL string, metadata map[string]interface{}) error {
+	return mc.store(registryURL, "metadata.json", metadata)
+}
+
+func (mc *MetadataCache) get(registryURL, filename string, ttl time.Duration, target interface{}) bool {
+	metadataPath := mc.storage.MetadataPath(registryURL)
+	filePath := filepath.Join(metadataPath, filename)
+
+	if !mc.storage.Exists(filePath) {
+		return false
+	}
+
+	if mc.storage.IsExpired(filePath, ttl) {
+		return false
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return false
+	}
+
+	return json.Unmarshal(data, target) == nil
+}
+
+func (mc *MetadataCache) store(registryURL, filename string, data interface{}) error {
+	metadataPath := mc.storage.MetadataPath(registryURL)
+	if err := os.MkdirAll(metadataPath, 0o755); err != nil {
+		return fmt.Errorf("failed to create metadata cache directory: %w", err)
+	}
+
+	filePath := filepath.Join(metadataPath, filename)
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, jsonData, 0o644); err != nil {
+		return fmt.Errorf("failed to write metadata cache: %w", err)
+	}
+
+	return nil
+}

--- a/internal/cache/metadata_test.go
+++ b/internal/cache/metadata_test.go
@@ -1,0 +1,99 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMetadataCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage := &Storage{basePath: tmpDir}
+	config := CacheConfig{
+		MetadataTTL: time.Hour,
+		VersionTTL:  15 * time.Minute,
+	}
+	mc := NewMetadataCache(storage, config)
+
+	registryURL := "https://registry.armjs.org/"
+
+	// Test versions cache miss
+	if _, found := mc.GetVersions(registryURL); found {
+		t.Error("Expected cache miss for non-existent versions")
+	}
+
+	// Test store and retrieve versions
+	versions := []string{"1.0.0", "1.1.0", "2.0.0"}
+	if err := mc.StoreVersions(registryURL, versions); err != nil {
+		t.Fatalf("Failed to store versions: %v", err)
+	}
+
+	cachedVersions, found := mc.GetVersions(registryURL)
+	if !found {
+		t.Error("Expected cache hit after storing versions")
+	}
+	if len(cachedVersions) != len(versions) {
+		t.Errorf("Cached versions length %d != stored length %d", len(cachedVersions), len(versions))
+	}
+	for i, v := range versions {
+		if cachedVersions[i] != v {
+			t.Errorf("Cached version[%d] %q != stored %q", i, cachedVersions[i], v)
+		}
+	}
+
+	// Test metadata cache miss
+	if _, found := mc.GetMetadata(registryURL); found {
+		t.Error("Expected cache miss for non-existent metadata")
+	}
+
+	// Test store and retrieve metadata
+	metadata := map[string]interface{}{
+		"name":        "test-registry",
+		"description": "Test registry",
+		"version":     "1.0.0",
+	}
+	if err := mc.StoreMetadata(registryURL, metadata); err != nil {
+		t.Fatalf("Failed to store metadata: %v", err)
+	}
+
+	cachedMetadata, found := mc.GetMetadata(registryURL)
+	if !found {
+		t.Error("Expected cache hit after storing metadata")
+	}
+	if cachedMetadata["name"] != metadata["name"] {
+		t.Errorf("Cached metadata name %q != stored %q", cachedMetadata["name"], metadata["name"])
+	}
+}
+
+func TestMetadataCacheExpiration(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage := &Storage{basePath: tmpDir}
+	config := CacheConfig{
+		MetadataTTL: time.Millisecond,
+		VersionTTL:  time.Millisecond,
+	}
+	mc := NewMetadataCache(storage, config)
+
+	registryURL := "https://registry.armjs.org/"
+
+	// Store versions and metadata
+	versions := []string{"1.0.0"}
+	metadata := map[string]interface{}{"test": "data"}
+
+	if err := mc.StoreVersions(registryURL, versions); err != nil {
+		t.Fatalf("Failed to store versions: %v", err)
+	}
+	if err := mc.StoreMetadata(registryURL, metadata); err != nil {
+		t.Fatalf("Failed to store metadata: %v", err)
+	}
+
+	// Wait for expiration
+	time.Sleep(2 * time.Millisecond)
+
+	// Test cache miss due to expiration
+	if _, found := mc.GetVersions(registryURL); found {
+		t.Error("Expected cache miss for expired versions")
+	}
+	if _, found := mc.GetMetadata(registryURL); found {
+		t.Error("Expected cache miss for expired metadata")
+	}
+}

--- a/internal/cache/packages.go
+++ b/internal/cache/packages.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type PackageCache struct {
+	storage *Storage
+	config  CacheConfig
+}
+
+func NewPackageCache(storage *Storage, config CacheConfig) *PackageCache {
+	return &PackageCache{
+		storage: storage,
+		config:  config,
+	}
+}
+
+func (pc *PackageCache) Get(registryURL, ruleset, version string) (string, bool) {
+	packagePath := pc.storage.PackagePath(registryURL, ruleset, version)
+	tarPath := filepath.Join(packagePath, "package.tar.gz")
+
+	if !pc.storage.Exists(tarPath) {
+		return "", false
+	}
+
+	if pc.storage.IsExpired(tarPath, pc.config.PackageTTL) {
+		return "", false
+	}
+
+	return tarPath, true
+}
+
+func (pc *PackageCache) Store(registryURL, ruleset, version string, data io.Reader) (string, error) {
+	packagePath := pc.storage.PackagePath(registryURL, ruleset, version)
+	if err := os.MkdirAll(packagePath, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create package cache directory: %w", err)
+	}
+
+	tarPath := filepath.Join(packagePath, "package.tar.gz")
+	file, err := os.Create(tarPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create cache file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	if _, err := io.Copy(file, data); err != nil {
+		_ = os.Remove(tarPath) // Clean up on failure
+		return "", fmt.Errorf("failed to write cache file: %w", err)
+	}
+
+	return tarPath, nil
+}

--- a/internal/cache/packages_test.go
+++ b/internal/cache/packages_test.go
@@ -1,0 +1,65 @@
+package cache
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPackageCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage := &Storage{basePath: tmpDir}
+	config := CacheConfig{PackageTTL: 0} // Never expire
+	pc := NewPackageCache(storage, config)
+
+	registryURL := "https://registry.armjs.org/"
+	ruleset := "typescript-rules"
+	version := "1.0.0"
+
+	// Test cache miss
+	if _, found := pc.Get(registryURL, ruleset, version); found {
+		t.Error("Expected cache miss for non-existent package")
+	}
+
+	// Test store
+	testData := strings.NewReader("test package data")
+	path, err := pc.Store(registryURL, ruleset, version, testData)
+	if err != nil {
+		t.Fatalf("Failed to store package: %v", err)
+	}
+
+	// Test cache hit
+	cachedPath, found := pc.Get(registryURL, ruleset, version)
+	if !found {
+		t.Error("Expected cache hit after storing package")
+	}
+	if cachedPath != path {
+		t.Errorf("Cached path %q != stored path %q", cachedPath, path)
+	}
+}
+
+func TestPackageCacheExpiration(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage := &Storage{basePath: tmpDir}
+	config := CacheConfig{PackageTTL: time.Millisecond} // Very short TTL
+	pc := NewPackageCache(storage, config)
+
+	registryURL := "https://registry.armjs.org/"
+	ruleset := "typescript-rules"
+	version := "1.0.0"
+
+	// Store package
+	testData := strings.NewReader("test package data")
+	_, err := pc.Store(registryURL, ruleset, version, testData)
+	if err != nil {
+		t.Fatalf("Failed to store package: %v", err)
+	}
+
+	// Wait for expiration
+	time.Sleep(2 * time.Millisecond)
+
+	// Test cache miss due to expiration
+	if _, found := pc.Get(registryURL, ruleset, version); found {
+		t.Error("Expected cache miss due to expiration")
+	}
+}

--- a/internal/cache/storage.go
+++ b/internal/cache/storage.go
@@ -1,0 +1,97 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type Storage struct {
+	basePath string
+}
+
+type CacheConfig struct {
+	PackageTTL  time.Duration
+	MetadataTTL time.Duration
+	VersionTTL  time.Duration
+}
+
+var DefaultConfig = CacheConfig{
+	PackageTTL:  0, // Never expire
+	MetadataTTL: time.Hour,
+	VersionTTL:  15 * time.Minute,
+}
+
+func New() (*Storage, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	basePath := filepath.Join(homeDir, ".arm", "cache")
+	if err := os.MkdirAll(basePath, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	return &Storage{basePath: basePath}, nil
+}
+
+func (s *Storage) PackagePath(registryURL, ruleset, version string) string {
+	host := extractHost(registryURL)
+	return filepath.Join(s.basePath, "packages", host, ruleset, version)
+}
+
+func (s *Storage) MetadataPath(registryURL string) string {
+	host := extractHost(registryURL)
+	return filepath.Join(s.basePath, "registry", host)
+}
+
+func extractHost(registryURL string) string {
+	if registryURL == "" {
+		return "unknown"
+	}
+
+	parsed, err := url.Parse(registryURL)
+	if err != nil {
+		// Fallback: hash the URL if parsing fails
+		hash := sha256.Sum256([]byte(registryURL))
+		return fmt.Sprintf("hash-%x", hash[:8])
+	}
+
+	host := parsed.Host
+	if host == "" {
+		// Handle file:// URLs and invalid URLs
+		if strings.HasPrefix(registryURL, "file://") {
+			host = strings.TrimPrefix(registryURL, "file://")
+			host = strings.ReplaceAll(host, string(filepath.Separator), "_")
+		} else {
+			// For URLs without host (like "invalid-url"), hash them
+			hash := sha256.Sum256([]byte(registryURL))
+			host = fmt.Sprintf("hash-%x", hash[:8])
+		}
+	}
+
+	return host
+}
+
+func (s *Storage) Exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func (s *Storage) IsExpired(path string, ttl time.Duration) bool {
+	if ttl == 0 {
+		return false // Never expires
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return true // Doesn't exist = expired
+	}
+
+	return time.Since(info.ModTime()) > ttl
+}

--- a/internal/cache/storage_test.go
+++ b/internal/cache/storage_test.go
@@ -1,0 +1,86 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestExtractHost(t *testing.T) {
+	tests := []struct {
+		url      string
+		expected string
+	}{
+		{"https://registry.armjs.org/", "registry.armjs.org"},
+		{"https://gitlab.company.com/api/v4", "gitlab.company.com"},
+		{"http://localhost:8080", "localhost:8080"},
+		{"file:///tmp/registry", "_tmp_registry"},
+		{"", "unknown"},
+		{"invalid-url", "hash-"},
+	}
+
+	for _, test := range tests {
+		result := extractHost(test.url)
+		if test.expected == "hash-" {
+			if len(result) < 13 || result[:5] != "hash-" {
+				t.Errorf("extractHost(%q) = %q, expected hash prefix", test.url, result)
+			}
+		} else if result != test.expected {
+			t.Errorf("extractHost(%q) = %q, expected %q", test.url, result, test.expected)
+		}
+	}
+}
+
+func TestStoragePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage := &Storage{basePath: tmpDir}
+
+	packagePath := storage.PackagePath("https://registry.armjs.org/", "typescript-rules", "1.0.0")
+	expected := filepath.Join(tmpDir, "packages", "registry.armjs.org", "typescript-rules", "1.0.0")
+	if packagePath != expected {
+		t.Errorf("PackagePath() = %q, expected %q", packagePath, expected)
+	}
+
+	metadataPath := storage.MetadataPath("https://registry.armjs.org/")
+	expected = filepath.Join(tmpDir, "registry", "registry.armjs.org")
+	if metadataPath != expected {
+		t.Errorf("MetadataPath() = %q, expected %q", metadataPath, expected)
+	}
+}
+
+func TestStorageExpiration(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage := &Storage{basePath: tmpDir}
+
+	// Create a test file
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test never expires (TTL = 0)
+	if storage.IsExpired(testFile, 0) {
+		t.Error("File should never expire with TTL = 0")
+	}
+
+	// Test not expired
+	if storage.IsExpired(testFile, time.Hour) {
+		t.Error("File should not be expired")
+	}
+
+	// Test expired (set file time to past)
+	pastTime := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(testFile, pastTime, pastTime); err != nil {
+		t.Fatal(err)
+	}
+
+	if !storage.IsExpired(testFile, time.Hour) {
+		t.Error("File should be expired")
+	}
+
+	// Test non-existent file
+	if !storage.IsExpired("nonexistent", time.Hour) {
+		t.Error("Non-existent file should be considered expired")
+	}
+}


### PR DESCRIPTION
- Add cache storage with global ~/.arm/cache location
- Implement package caching with tar.gz storage
- Add metadata caching for registry data and version lists
- Use registry URL hostname + ruleset name as cache keys
- Configure TTLs: packages (never), metadata (1h), versions (15m)
- Graceful fallback when cache unavailable
- Comprehensive unit tests covering all cache functionality
- Update documentation to reflect global cache structure