### PR TITLE
feat: implement elegant Git registry version resolution and manifest …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ __pycache__/
 *.pyc
 
 node_modules
+
+sandbox/

--- a/internal/config/manifest.go
+++ b/internal/config/manifest.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ManifestManager handles arm.json file operations
+type ManifestManager struct {
+	path string
+}
+
+// NewManifestManager creates a new manifest manager
+func NewManifestManager(global bool) *ManifestManager {
+	path := "arm.json"
+	if global {
+		path = filepath.Join(os.Getenv("HOME"), ".arm", "arm.json")
+	}
+	return &ManifestManager{path: path}
+}
+
+// AddRuleset adds or updates a ruleset in the manifest
+func (m *ManifestManager) AddRuleset(registry, name, version string, patterns []string) error {
+	armConfig, err := m.loadOrCreate()
+	if err != nil {
+		return err
+	}
+
+	// Initialize registry map if needed
+	if armConfig.Rulesets[registry] == nil {
+		armConfig.Rulesets[registry] = make(map[string]RulesetSpec)
+	}
+
+	// Update ruleset entry
+	armConfig.Rulesets[registry][name] = RulesetSpec{
+		Version:  version,
+		Patterns: patterns,
+	}
+
+	return m.save(armConfig)
+}
+
+// RemoveRuleset removes a ruleset from the manifest
+func (m *ManifestManager) RemoveRuleset(registry, name string) error {
+	armConfig, err := m.loadOrCreate()
+	if err != nil {
+		return err
+	}
+
+	if armConfig.Rulesets[registry] != nil {
+		delete(armConfig.Rulesets[registry], name)
+		// Remove registry if empty
+		if len(armConfig.Rulesets[registry]) == 0 {
+			delete(armConfig.Rulesets, registry)
+		}
+	}
+
+	return m.save(armConfig)
+}
+
+// loadOrCreate loads existing manifest or creates a new one
+func (m *ManifestManager) loadOrCreate() (*ARMConfig, error) {
+	if _, err := os.Stat(m.path); os.IsNotExist(err) {
+		// Create parent directory if needed
+		if err := os.MkdirAll(filepath.Dir(m.path), 0o755); err != nil {
+			return nil, err
+		}
+		return &ARMConfig{
+			Engines:  make(map[string]string),
+			Channels: make(map[string]ChannelConfig),
+			Rulesets: make(map[string]map[string]RulesetSpec),
+		}, nil
+	}
+
+	data, err := os.ReadFile(m.path)
+	if err != nil {
+		return nil, err
+	}
+
+	var armConfig ARMConfig
+	if err := json.Unmarshal(data, &armConfig); err != nil {
+		return nil, err
+	}
+
+	// Initialize maps if nil
+	if armConfig.Engines == nil {
+		armConfig.Engines = make(map[string]string)
+	}
+	if armConfig.Channels == nil {
+		armConfig.Channels = make(map[string]ChannelConfig)
+	}
+	if armConfig.Rulesets == nil {
+		armConfig.Rulesets = make(map[string]map[string]RulesetSpec)
+	}
+
+	return &armConfig, nil
+}
+
+// save saves the manifest to disk
+func (m *ManifestManager) save(armConfig *ARMConfig) error {
+	data, err := json.MarshalIndent(armConfig, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+	return os.WriteFile(m.path, data, 0o600)
+}

--- a/internal/registry/gitlab.go
+++ b/internal/registry/gitlab.go
@@ -126,6 +126,14 @@ func (g *GitLabRegistry) GetRuleset(ctx context.Context, name, version string) (
 
 // DownloadRuleset downloads a ruleset to the specified directory
 func (g *GitLabRegistry) DownloadRuleset(ctx context.Context, name, version, destDir string) error {
+	return g.DownloadRulesetWithPatterns(ctx, name, version, destDir, nil)
+}
+
+// DownloadRulesetWithPatterns downloads a ruleset (patterns ignored for GitLab)
+func (g *GitLabRegistry) DownloadRulesetWithPatterns(ctx context.Context, name, version, destDir string, patterns []string) error {
+	// GitLab registries use pre-packaged tar.gz files, so patterns are ignored
+	_ = patterns
+
 	// Construct GitLab Generic Packages API URL
 	url := fmt.Sprintf("%s/api/v4/projects/%s/packages/generic/%s/%s/ruleset.tar.gz",
 		g.baseURL, g.projectID, name, version)

--- a/internal/registry/https.go
+++ b/internal/registry/https.go
@@ -119,6 +119,14 @@ func (h *HTTPSRegistry) GetRuleset(ctx context.Context, name, version string) (*
 
 // DownloadRuleset downloads a ruleset to the specified directory
 func (h *HTTPSRegistry) DownloadRuleset(ctx context.Context, name, version, destDir string) error {
+	return h.DownloadRulesetWithPatterns(ctx, name, version, destDir, nil)
+}
+
+// DownloadRulesetWithPatterns downloads a ruleset (patterns ignored for HTTPS)
+func (h *HTTPSRegistry) DownloadRulesetWithPatterns(ctx context.Context, name, version, destDir string, patterns []string) error {
+	// HTTPS registries use pre-packaged tar.gz files, so patterns are ignored
+	_ = patterns
+
 	// Construct download URL: baseURL/ruleset/version/ruleset.tar.gz
 	url := fmt.Sprintf("%s/%s/%s/ruleset.tar.gz", h.baseURL, name, version)
 

--- a/internal/registry/local.go
+++ b/internal/registry/local.go
@@ -145,6 +145,14 @@ func (l *LocalRegistry) GetRuleset(ctx context.Context, name, version string) (*
 
 // DownloadRuleset copies a ruleset from the local filesystem to the specified directory
 func (l *LocalRegistry) DownloadRuleset(ctx context.Context, name, version, destDir string) error {
+	return l.DownloadRulesetWithPatterns(ctx, name, version, destDir, nil)
+}
+
+// DownloadRulesetWithPatterns copies a ruleset (patterns ignored for Local)
+func (l *LocalRegistry) DownloadRulesetWithPatterns(ctx context.Context, name, version, destDir string, patterns []string) error {
+	// Local registries use pre-packaged tar.gz files, so patterns are ignored
+	_ = patterns
+
 	// Construct source path: path/ruleset/version/ruleset.tar.gz
 	sourcePath := filepath.Join(l.path, name, version, "ruleset.tar.gz")
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -19,6 +19,9 @@ type Registry interface {
 	// DownloadRuleset downloads a ruleset to the specified directory
 	DownloadRuleset(ctx context.Context, name, version, destDir string) error
 
+	// DownloadRulesetWithPatterns downloads a ruleset with pattern matching (for Git registries)
+	DownloadRulesetWithPatterns(ctx context.Context, name, version, destDir string, patterns []string) error
+
 	// GetVersions returns available versions for a ruleset
 	GetVersions(ctx context.Context, name string) ([]string, error)
 

--- a/internal/registry/s3.go
+++ b/internal/registry/s3.go
@@ -128,6 +128,14 @@ func (s *S3Registry) GetRuleset(ctx context.Context, name, version string) (*Rul
 
 // DownloadRuleset downloads a ruleset to the specified directory
 func (s *S3Registry) DownloadRuleset(ctx context.Context, name, version, destDir string) error {
+	return s.DownloadRulesetWithPatterns(ctx, name, version, destDir, nil)
+}
+
+// DownloadRulesetWithPatterns downloads a ruleset (patterns ignored for S3)
+func (s *S3Registry) DownloadRulesetWithPatterns(ctx context.Context, name, version, destDir string, patterns []string) error {
+	// S3 registries use pre-packaged tar.gz files, so patterns are ignored
+	_ = patterns
+
 	// Construct the S3 key for the ruleset tarball
 	key := s.prefix + name + "/" + version + "/ruleset.tar.gz"
 

--- a/test-setup-git-registry-procedure.sh
+++ b/test-setup-git-registry-procedure.sh
@@ -1,0 +1,12 @@
+# install git repo test procedure
+
+make build
+rm -rf sandbox
+mkdir sandbox
+cd sandbox
+../bin/arm version
+../bin/arm install
+../bin/arm clean all --force
+../bin/arm config add registry default https://github.com/PatrickJS/awesome-cursorrules --type=git
+../bin/arm config add channel q --directories ./amazonq/rules
+../bin/arm install python --patterns "rules-new/python.mdc"


### PR DESCRIPTION
…updates

- Add ManifestManager in config package for clean separation of concerns

- Create DownloadResult struct for structured Git registry responses

- Implement performGitInstallation for Git-specific installation flow

- Remove ResolveVersion from Registry interface to avoid pollution

- Fix arm.json to store original version specs, arm.lock stores resolved hashes

- Clean architecture with single responsibility principle