### PR TITLE
fix!: remove version from urf schema

### DIFF
--- a/docs/universal-rule-format.md
+++ b/docs/universal-rule-format.md
@@ -24,7 +24,6 @@ version: "1.0"
 metadata:
   id: "grug-brained-dev"
   name: "Grug-Brained Developer Rules"
-  version: "1.0.0"  # required
   description: "Simple, obvious coding practices"  # optional
 rules:
   simple-code:  # Rule ID as map key
@@ -66,7 +65,6 @@ rules:
 ### Metadata Section
 - **`id`** (required): Unique identifier for the ruleset
 - **`name`** (required): Human-readable ruleset name
-- **`version`** (required): Semantic version (e.g., "1.0.0")
 - **`description`** (optional): Brief description of the ruleset's purpose
 
 ### Rules Section

--- a/internal/arm/service_compile_integration_test.go
+++ b/internal/arm/service_compile_integration_test.go
@@ -21,7 +21,6 @@ func TestArmService_CompileFiles_Integration(t *testing.T) {
 metadata:
   id: "integration-test"
   name: "Integration Test Rules"
-  version: "1.0.0"
 rules:
   rule1:
     name: "Test Rule 1"
@@ -81,7 +80,6 @@ func TestArmService_CompileFiles_MultiTarget_Integration(t *testing.T) {
 metadata:
   id: "multi-target-test"
   name: "Multi Target Test Rules"
-  version: "1.0.0"
 rules:
   rule1:
     name: "Test Rule"

--- a/internal/arm/service_compile_test.go
+++ b/internal/arm/service_compile_test.go
@@ -135,7 +135,6 @@ func TestArmService_validateURFFile(t *testing.T) {
 metadata:
   id: "test-rules"
   name: "Test Rules"
-  version: "1.0.0"
 rules:
   rule1:
     name: "Test Rule"
@@ -176,7 +175,6 @@ func TestArmService_CompileFiles_ValidateOnly(t *testing.T) {
 metadata:
   id: "test-rules"
   name: "Test Rules"
-  version: "1.0.0"
 rules:
   rule1:
     name: "Test Rule"

--- a/internal/index/generator.go
+++ b/internal/index/generator.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	"github.com/jomadu/ai-rules-manager/internal/urf"
-	"github.com/jomadu/ai-rules-manager/internal/version"
 )
 
 type IndexGenerator interface {
@@ -19,9 +18,8 @@ func (g *DefaultIndexGenerator) CreateRuleset(data *IndexData) *urf.Ruleset {
 	return &urf.Ruleset{
 		Version: "1.0",
 		Metadata: urf.Metadata{
-			ID:      "arm",
-			Name:    "ARM Rulesets Index",
-			Version: version.Version,
+			ID:   "arm",
+			Name: "ARM Rulesets Index",
 		},
 		Rules: map[string]urf.Rule{
 			"index": {

--- a/internal/index/generator_test.go
+++ b/internal/index/generator_test.go
@@ -3,8 +3,6 @@ package index
 import (
 	"strings"
 	"testing"
-
-	"github.com/jomadu/ai-rules-manager/internal/version"
 )
 
 func TestDefaultIndexGenerator_CreateRuleset(t *testing.T) {
@@ -28,9 +26,6 @@ func TestDefaultIndexGenerator_CreateRuleset(t *testing.T) {
 
 	if ruleset.Metadata.ID != "arm" {
 		t.Errorf("expected ID 'arm', got %s", ruleset.Metadata.ID)
-	}
-	if ruleset.Metadata.Version != version.Version {
-		t.Errorf("expected version %s, got %s", version.Version, ruleset.Metadata.Version)
 	}
 	if len(ruleset.Rules) != 1 {
 		t.Errorf("expected 1 rule, got %d", len(ruleset.Rules))

--- a/internal/urf/compiler_test.go
+++ b/internal/urf/compiler_test.go
@@ -17,9 +17,8 @@ func TestDefaultCompiler_Compile(t *testing.T) {
 	ruleset := &Ruleset{
 		Version: "1.0",
 		Metadata: Metadata{
-			ID:      "test-ruleset",
-			Name:    "Test Ruleset",
-			Version: "1.0.0",
+			ID:   "test-ruleset",
+			Name: "Test Ruleset",
 		},
 		Rules: map[string]Rule{
 			"rule1": {
@@ -108,9 +107,8 @@ func TestDefaultCompiler_AmazonQTarget(t *testing.T) {
 	ruleset := &Ruleset{
 		Version: "1.0",
 		Metadata: Metadata{
-			ID:      "test-ruleset",
-			Name:    "Test Ruleset",
-			Version: "1.0.0",
+			ID:   "test-ruleset",
+			Name: "Test Ruleset",
 		},
 		Rules: map[string]Rule{
 			"rule1": {

--- a/internal/urf/cursor_rule_generator_test.go
+++ b/internal/urf/cursor_rule_generator_test.go
@@ -14,7 +14,6 @@ func TestCursorRuleGenerator_GenerateRule(t *testing.T) {
 		Metadata: Metadata{
 			ID:          "test-ruleset",
 			Name:        "Test Ruleset",
-			Version:     "1.0.0",
 			Description: "Test description",
 		},
 		Rules: map[string]Rule{
@@ -73,7 +72,7 @@ func TestCursorRuleGenerator_GenerateRule_ShouldEnforcement(t *testing.T) {
 	}
 
 	ruleset := &Ruleset{
-		Metadata: Metadata{ID: "test", Name: "Test", Version: "1.0.0"},
+		Metadata: Metadata{ID: "test", Name: "Test"},
 		Rules: map[string]Rule{
 			"rule1": {
 				Name:        "Test Rule",

--- a/internal/urf/markdown_rule_generator_test.go
+++ b/internal/urf/markdown_rule_generator_test.go
@@ -12,9 +12,8 @@ func TestMarkdownRuleGenerator_GenerateRule(t *testing.T) {
 
 	ruleset := &Ruleset{
 		Metadata: Metadata{
-			ID:      "test-ruleset",
-			Name:    "Test Ruleset",
-			Version: "1.0.0",
+			ID:   "test-ruleset",
+			Name: "Test Ruleset",
 		},
 		Rules: map[string]Rule{
 			"rule1": {

--- a/internal/urf/rule_metadata_generator.go
+++ b/internal/urf/rule_metadata_generator.go
@@ -22,9 +22,6 @@ func (g *DefaultRuleMetadataGenerator) GenerateRuleMetadata(namespace string, ru
 	content.WriteString("ruleset:\n")
 	content.WriteString(fmt.Sprintf("  id: %s\n", ruleset.Metadata.ID))
 	content.WriteString(fmt.Sprintf("  name: %s\n", ruleset.Metadata.Name))
-	if ruleset.Metadata.Version != "" {
-		content.WriteString(fmt.Sprintf("  version: %s\n", ruleset.Metadata.Version))
-	}
 	content.WriteString("  rules:\n")
 	for id := range ruleset.Rules {
 		content.WriteString(fmt.Sprintf("    - %s\n", id))

--- a/internal/urf/rule_metadata_generator_test.go
+++ b/internal/urf/rule_metadata_generator_test.go
@@ -10,9 +10,8 @@ func TestDefaultRuleMetadataGenerator_GenerateRuleMetadata(t *testing.T) {
 
 	ruleset := &Ruleset{
 		Metadata: Metadata{
-			ID:      "test-ruleset",
-			Name:    "Test Ruleset",
-			Version: "1.0.0",
+			ID:   "test-ruleset",
+			Name: "Test Ruleset",
 		},
 		Rules: map[string]Rule{
 			"rule1": {Name: "Rule 1"},
@@ -44,9 +43,6 @@ func TestDefaultRuleMetadataGenerator_GenerateRuleMetadata(t *testing.T) {
 	}
 	if !strings.Contains(result, "name: Test Ruleset") {
 		t.Error("Expected ruleset name in metadata")
-	}
-	if !strings.Contains(result, "version: 1.0.0") {
-		t.Error("Expected ruleset version in metadata")
 	}
 
 	// Check rules list
@@ -86,7 +82,7 @@ func TestDefaultRuleMetadataGenerator_GenerateRuleMetadata_NoScope(t *testing.T)
 	generator := NewRuleMetadataGenerator()
 
 	ruleset := &Ruleset{
-		Metadata: Metadata{ID: "test", Name: "Test", Version: "1.0.0"},
+		Metadata: Metadata{ID: "test", Name: "Test"},
 		Rules:    map[string]Rule{"rule1": {}},
 	}
 

--- a/internal/urf/types.go
+++ b/internal/urf/types.go
@@ -13,7 +13,6 @@ type Ruleset struct {
 type Metadata struct {
 	ID          string `yaml:"id" validate:"required"`
 	Name        string `yaml:"name" validate:"required"`
-	Version     string `yaml:"version" validate:"required"`
 	Description string `yaml:"description,omitempty"`
 }
 

--- a/scripts/workflows/compile/example-rulesets/clean-code.yml
+++ b/scripts/workflows/compile/example-rulesets/clean-code.yml
@@ -2,7 +2,6 @@ version: "1.0"
 metadata:
   id: "clean-code"
   name: "Clean Code Guidelines"
-  version: "1.0.0"
 rules:
   naming:
     name: "Meaningful Names"

--- a/scripts/workflows/compile/example-rulesets/security.yml
+++ b/scripts/workflows/compile/example-rulesets/security.yml
@@ -2,7 +2,6 @@ version: "1.0"
 metadata:
   id: "security"
   name: "Security Best Practices"
-  version: "1.0.0"
 rules:
   input-validation:
     name: "Input Validation"


### PR DESCRIPTION
we don't actually need the version as part of the schema for urf. it's prone to drift between the package version and the documented version in the file.